### PR TITLE
fix attributes kebab case

### DIFF
--- a/kapa-gitbook-integration/src/script.raw.js
+++ b/kapa-gitbook-integration/src/script.raw.js
@@ -89,7 +89,7 @@
     s.setAttribute("data-project-logo", PROJECT_LOGO);
 
     for (const [key, value] of Object.entries(config)) {
-      const kebabCaseKey = key.replace("_", "-").toLowerCase();
+      const kebabCaseKey = key.replaceAll("_", "-").toLowerCase();
       if (value !== "undefined") {
         s.setAttribute(`data-${kebabCaseKey}`, value);
       }

--- a/kapa-gitbook-integration/src/script.raw.js
+++ b/kapa-gitbook-integration/src/script.raw.js
@@ -90,7 +90,7 @@
 
     for (const [key, value] of Object.entries(config)) {
       const kebabCaseKey = key.replaceAll("_", "-").toLowerCase();
-      if (value !== "undefined") {
+      if (value !== `<${key}>` && value !== "undefined") {
         s.setAttribute(`data-${kebabCaseKey}`, value);
       }
     }


### PR DESCRIPTION
This PR fixes a bug in the Gitbook script. When transforming attributes from JS variables to script tag attributes, we were using `key.replace("_", "-")` to transform from snake case to kebab case. However, in JS this only replaces the first occurrence, leading to strings like `button-text_color`. This is contrary to Python, where `replace` replaces **all** occurrences...

So this PR changes `replace` to `replaceAll` ([see MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll)).

Note: This is untested because I can't publish to Gitbook atm (same problem as always), but I'm fairly confident that this fixes it.